### PR TITLE
Prevent extra queries during prune revisions, potentially other areas

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -163,7 +163,9 @@ class Scout extends Plugin
             function (ElementEvent $event) {
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
-                $this->beforeDeleteRelated = $element->getRelatedElements();
+                if ($element->shouldBeSearchable()) {
+                    $this->beforeDeleteRelated = $element->getRelatedElements();
+                }
             }
         );
 
@@ -173,13 +175,16 @@ class Scout extends Plugin
             function (ElementEvent $event) {
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
-                $element->unsearchable();
+                
+                if ($element->shouldBeSearchable()) {
+                    $element->unsearchable();
 
-                if ($this->beforeDeleteRelated) {
-                    $this->beforeDeleteRelated->each(function (Element $relatedElement) {
-                        /* @var SearchableBehavior $relatedElement */
-                        $relatedElement->searchable(false);
-                    });
+                    if ($this->beforeDeleteRelated) {
+                        $this->beforeDeleteRelated->each(function (Element $relatedElement) {
+                            /* @var SearchableBehavior $relatedElement */
+                            $relatedElement->searchable(false);
+                        });
+                    }
                 }
             }
         );

--- a/src/Scout.php
+++ b/src/Scout.php
@@ -175,7 +175,7 @@ class Scout extends Plugin
             function (ElementEvent $event) {
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
-                
+
                 if ($element->shouldBeSearchable()) {
                     $element->unsearchable();
 


### PR DESCRIPTION
I noticed while debugging why the `utils/prune-revisions` console command was running so slow on a site with tens of millions of relations. After debugging, I realized disabling Scout caused the command to run blazing fast. Further digging made me realize that the getRelatedElements call was getting called with every single deleted element (and subelements, such as matrix or supertable elements) because there was no check to see if the element should be searchable to begin with. This commit adds in that check, causing the sync config item, propogating element state, and draft/revisionness to be respected during deletion where it was not before.