### PR TITLE
Expose index settings commands via CP utility

### DIFF
--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -3,6 +3,7 @@
 namespace rias\scout\controllers;
 
 use Craft;
+use craft\helpers\Json;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
 use rias\scout\engines\Engine;
@@ -62,6 +63,30 @@ class IndexController extends Controller
         $this->actionImport();
 
         return $this->redirect(UrlHelper::url('utilities/'.ScoutUtility::id()));
+    }
+
+    public function actionUpdateSettings()
+    {
+        $this->requirePostRequest();
+
+        $engine = $this->getEngine();
+        $engine->updateSettings($engine->scoutIndex->indexSettings);
+
+        Craft::$app->getSession()->setNotice("Updated settings for index {$engine->scoutIndex->indexName}");
+
+        return $this->redirect(UrlHelper::url('utilities/'.ScoutUtility::id()));
+    }
+
+    public function actionDumpSettings()
+    {
+        $engine = $this->getEngine();
+        $settings = $engine->getSettings();
+        $content = Json::encode($settings, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        $attachmentName = "scout-{$engine->scoutIndex->indexName}-settings.json";
+    
+        return $this->response->sendContentAsFile($content, $attachmentName, [
+            'mimeType' => 'application/json',
+        ]);
     }
 
     private function getEngine(): Engine

--- a/src/templates/_partials/action.twig
+++ b/src/templates/_partials/action.twig
@@ -1,4 +1,4 @@
-<form method="post" accept-charset="UTF-8">
+<form style="margin-bottom:4px;" method="post" accept-charset="UTF-8">
     {{ csrfInput() }}
     <input type="hidden" name="action" value="{{ 'scout/index/'~action.slug }}">
     <input type="hidden" name="index" value="{{ action.index }}">

--- a/src/templates/utility.twig
+++ b/src/templates/utility.twig
@@ -49,6 +49,22 @@
                                 index: index.name
                             }
                         } %}
+                        &nbsp;
+                        {% include 'scout/_partials/action' with {
+                            action: {
+                                name: 'Update Settings' | t('scout'),
+                                slug: 'update-settings',
+                                index: index.name
+                            }
+                        } %}
+                        &nbsp;
+                        {% include 'scout/_partials/action' with {
+                            action: {
+                                name: 'Dump Settings' | t('scout'),
+                                slug: 'dump-settings',
+                                index: index.name
+                            }
+                        } %}
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Adds two new buttons to the action rows for each index in the`Scout Indices` utility:

- `Update Settings` - Update the Algolia index settings using the Scout config
- `Dump Settings` - Download JSON export of the current index settings from Algolia

Closes #207