### PR TITLE
Make the queue TTR and priority configurable

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -34,6 +34,12 @@ return [
     'ttr' => 300,
 
     /*
+     * If queue is enabled, you can override the default priority for a job.
+     * https://www.yiiframework.com/extension/yiisoft/yii2-queue/doc/api/2.0/yii-queue-queue#priority()-detail
+     */
+    'priority' => 1024,
+
+    /*
      * The connection timeout (in seconds), increase this only if necessary
      */
     'connect_timeout' => 1,

--- a/config/scout.php
+++ b/config/scout.php
@@ -28,6 +28,12 @@ return [
     'queue' => true,
 
     /*
+     * If queue is enabled, you can override the default time-to-reserve a job.
+     * https://www.yiiframework.com/extension/yiisoft/yii2-queue/doc/api/2.0/yii-queue-queue#$ttr-detail
+     */
+    'ttr' => 300,
+
+    /*
      * The connection timeout (in seconds), increase this only if necessary
      */
     'connect_timeout' => 1,

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -34,6 +34,7 @@ class IndexController extends Controller
         if (Scout::$plugin->getSettings()->queue) {
             Craft::$app->getQueue()
                 ->ttr(Scout::$plugin->getSettings()->ttr)
+                ->priority(Scout::$plugin->getSettings()->priority)
                 ->push(new ImportIndex([
                     'indexName' => $engine->scoutIndex->indexName,
                 ]));

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -32,9 +32,11 @@ class IndexController extends Controller
         $engine = $this->getEngine();
 
         if (Scout::$plugin->getSettings()->queue) {
-            Craft::$app->getQueue()->push(new ImportIndex([
-                'indexName' => $engine->scoutIndex->indexName,
-            ]));
+            Craft::$app->getQueue()
+                ->ttr(Scout::$plugin->getSettings()->ttr)
+                ->push(new ImportIndex([
+                    'indexName' => $engine->scoutIndex->indexName,
+                ]));
 
             Craft::$app->getSession()->setNotice("Queued job to update element(s) in {$engine->scoutIndex->indexName}");
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -24,6 +24,9 @@ class Settings extends Model
     /** @var bool */
     public $queue = true;
 
+    /** @var int */
+    public $ttr = 300;
+
     /** @var string */
     public $engine = AlgoliaEngine::class;
 
@@ -66,7 +69,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['connect_timeout', 'batch_size'], 'integer'],
+            [['connect_timeout', 'batch_size', 'ttr'], 'integer'],
             [['sync', 'queue'], 'boolean'],
             [['application_id', 'admin_api_key', 'search_api_key'], 'string'],
             [['application_id', 'admin_api_key', 'connect_timeout'], 'required'],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,6 +27,9 @@ class Settings extends Model
     /** @var int */
     public $ttr = 300;
 
+    /** @var int */
+    public $priority = 1024;
+
     /** @var string */
     public $engine = AlgoliaEngine::class;
 
@@ -69,7 +72,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['connect_timeout', 'batch_size', 'ttr'], 'integer'],
+            [['connect_timeout', 'batch_size', 'ttr', 'priority'], 'integer'],
             [['sync', 'queue'], 'boolean'],
             [['application_id', 'admin_api_key', 'search_api_key'], 'string'],
             [['application_id', 'admin_api_key', 'connect_timeout'], 'required'],


### PR DESCRIPTION
This adds the [ttr](https://www.yiiframework.com/extension/yiisoft/yii2-queue/doc/api/2.0/yii-queue-queue#$ttr-detail) and [priority](https://www.yiiframework.com/extension/yiisoft/yii2-queue/doc/api/2.0/yii-queue-queue#priority()-detail) queue settings to the config 