### PR TITLE
Add support for indexing split object without array when solo (#193)

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -62,4 +62,13 @@ return [
      * index should define an ElementType, criteria and a transformer.
      */
     'indices'       => [],
+
+    /**
+     * Elements can create multiple records by using `splitElementsOn()`,
+     * which split the element on specified array values. If the array has just one item,
+     * no splitting occurs. The legacy and default behavior is to simply use the
+     * original, unchanged record, which means the value is still wrapped in an array.
+     * Make this false to use the single item itself.
+     */
+    'useOriginalRecordIfSplitValueIsArrayOfOne' => true,
 ];

--- a/src/engines/Engine.php
+++ b/src/engines/Engine.php
@@ -4,6 +4,7 @@ namespace rias\scout\engines;
 
 use Algolia\AlgoliaSearch\SearchClient;
 use rias\scout\IndexSettings;
+use rias\scout\Scout;
 use rias\scout\ScoutIndex;
 
 abstract class Engine
@@ -34,8 +35,15 @@ abstract class Engine
             $splittedObjects = $this->splitObject($object);
 
             if (count($splittedObjects) <= 1) {
-                $object['distinctID'] = $object['objectID'];
-                $objectsToSave[] = $object;
+                if (Scout::$plugin->getSettings()->useOriginalRecordIfSplitValueIsArrayOfOne) {
+                    $object['distinctID'] = $object['objectID'];
+                    $objectsToSave[] = $object;
+                } else {
+                    $objectToSave = $splittedObjects[0] ?? $object;
+                    $objectToSave['distinctID'] = $objectToSave['objectID'];
+                    $objectsToSave[] = $objectToSave;
+                }
+
                 continue;
             }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -45,6 +45,9 @@ class Settings extends Model
     /* @var int */
     public $batch_size = 1000;
 
+    /** @var bool */
+    public $useOriginalRecordIfSplitValueIsArrayOfOne = true;
+
     public function fields()
     {
         $fields = parent::fields();
@@ -67,7 +70,7 @@ class Settings extends Model
     {
         return [
             [['connect_timeout', 'batch_size'], 'integer'],
-            [['sync', 'queue'], 'boolean'],
+            [['sync', 'queue', 'useOriginalRecordIfSplitValueIsArrayOfOne'], 'boolean'],
             [['application_id', 'admin_api_key', 'search_api_key'], 'string'],
             [['application_id', 'admin_api_key', 'connect_timeout'], 'required'],
         ];


### PR DESCRIPTION
This PR is following up on https://github.com/studioespresso/craft-scout/issues/193, where I provide more context for the current limitation with splitting objects. But in short, this adds a backwards-compatible setting to opt-in for using the individual object -- not an array-wrapped object -- when there is just a single`$splittedObjects`.

The setting name is admittedly cumbersome...couldn't think of a shorter name that was as clear!