### PR TITLE
Disabling relations on deletion when configured

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -18,6 +18,7 @@ use rias\scout\behaviors\SearchableBehavior;
 use rias\scout\models\Settings;
 use rias\scout\utilities\ScoutUtility;
 use rias\scout\variables\ScoutVariable;
+use Tightenco\Collect\Support\Collection;
 use yii\base\Event;
 
 class Scout extends Plugin
@@ -161,6 +162,11 @@ class Scout extends Plugin
             Elements::class,
             Elements::EVENT_BEFORE_DELETE_ELEMENT,
             function (ElementEvent $event) {
+                if (!Scout::$plugin->getSettings()->indexRelations) {
+                    $this->beforeDeleteRelated = new Collection();
+                    return;
+                }
+
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
                 $this->beforeDeleteRelated = $element->getRelatedElements();


### PR DESCRIPTION
This is an extension of this commit, https://github.com/studioespresso/craft-scout/commit/8504f0d04cbedfb821e160d0db7cdc54ceabe0ed which comes from this issue, https://github.com/studioespresso/craft-scout/issues/205. The issue that this resolves is that when `maxRevisions` is set in Craft a save of one entry also triggers a delete of old revisions/elements. That can cause issues on large datasets because the `getRelatedElements` can be very costly to do during an actual request.