### PR TITLE
Typesense support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "php": ">=7.1",
         "craftcms/cms": "^4.3.5",
         "algolia/algoliasearch-client-php": "^2.3|^3.0",
-        "league/fractal": "^0.18|^0.19"
+        "league/fractal": "^0.18|^0.19",
+        "typesense/typesense-php": "^4.8"
     },
     "repositories": [
         {
@@ -62,7 +63,8 @@
     "config": {
         "allow-plugins": {
             "yiisoft/yii2-composer": true,
-            "craftcms/plugin-installer": true
+            "craftcms/plugin-installer": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -23,7 +23,7 @@ use rias\scout\events\ShouldBeSearchableEvent;
 use rias\scout\jobs\MakeSearchable;
 use rias\scout\Scout;
 use rias\scout\ScoutIndex;
-use rias\scout\serializer\AlgoliaSerializer;
+use rias\scout\serializer\Serializer;
 use yii\base\Behavior;
 use yii\base\Event;
 
@@ -112,7 +112,7 @@ class SearchableBehavior extends Behavior
     public function toSearchableArray(ScoutIndex $scoutIndex): array
     {
         return (new Manager())
-            ->setSerializer(new AlgoliaSerializer())
+            ->setSerializer(new Serializer())
             ->createData(new Item($this->owner, $scoutIndex->getTransformer()))
             ->toArray();
     }

--- a/src/engines/Engine.php
+++ b/src/engines/Engine.php
@@ -12,7 +12,8 @@ abstract class Engine
     /** @var ScoutIndex */
     public $scoutIndex;
 
-    abstract public function __construct(ScoutIndex $scoutIndex, SearchClient $algolia);
+    // NOTE: not sure what the type of $client should be
+    // abstract public function __construct(ScoutIndex $scoutIndex, $client);
 
     abstract public function update($models);
 

--- a/src/engines/TypesenseEngine.php
+++ b/src/engines/TypesenseEngine.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace rias\scout\engines;
+
+use Typesense\Client as Typesense;
+use craft\base\Element;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use rias\scout\IndexSettings;
+use rias\scout\ScoutIndex;
+
+class TypesenseEngine extends Engine
+{
+    /** @var \Typesense\Client */
+    protected $typesense;
+
+    /** @var \rias\scout\ScoutIndex */
+    public $scoutIndex;
+
+    public function __construct(ScoutIndex $scoutIndex, Typesense $typesense)
+    {
+        $this->scoutIndex = $scoutIndex;
+        $this->typesense = $typesense;
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param array|Element $elements
+     *
+     * @throws \Algolia\AlgoliaSearch\Exceptions\AlgoliaException
+     */
+    public function update($elements)
+    {
+        $elements = new Collection(Arr::wrap($elements));
+
+        $elements = $elements->filter(function (Element $element) {
+            return get_class($element) === $this->scoutIndex->elementType;
+        });
+
+        if ($elements->isEmpty()) {
+            return;
+        }
+
+        $objects = $this->transformElements($elements);
+
+        if (!empty($objects)) {
+            $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+
+            return $collection->documents->import($objects, ['action' => 'upsert']);
+        }
+    }
+
+    public function delete($elements)
+    {
+        $elements = new Collection(Arr::wrap($elements));
+
+        $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+
+        $objectIds = $elements->map(function ($object) {
+            if ($object instanceof Element) {
+                return $object->id;
+            }
+
+            return $object['distinctID'] ?? $object['objectID'];
+        })->unique()->values()->all();
+
+        if (empty($objectIds)) {
+            return;
+        }
+
+        // if (empty($this->scoutIndex->splitElementsOn)) {
+        //     return $index->deleteObjects($objectIds);
+        // }
+
+        return $index->delete([
+            'filter_by' => 'objectID:['.implode(", ", $objectIds).']',
+        ]);
+    }
+
+    public function flush()
+    {
+        $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+
+        $collection->documents->delete(['filter_by' => 'objectID:>=0']);
+    }
+
+    public function updateSettings(IndexSettings $indexSettings)
+    {
+        // $this->typesense->collections[$this->scoutIndex->indexName]->delete();
+        // $this->typesense->collections->create([
+        //     'name' => $this->scoutIndex->indexName,
+        //     'fields' => [
+        //         [ 'name' => 'objectID', 'type' => 'int32' ],
+        //         [ 'name' => '.*', 'type' => 'auto' ]
+        //     ]
+        // ]);
+
+        $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+
+        return $collection->update($indexSettings);
+    }
+
+    public function getSettings(): array
+    {
+        $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+        
+        return $collection->retrieve();
+    }
+
+    public function getTotalRecords(): int
+    {
+        $collection = $this->typesense->collections[$this->scoutIndex->indexName];
+
+        $response = $collection->retrieve();
+
+        return (int) $response['num_documents'];
+    }
+
+    private function transformElements(Collection $elements): array
+    {
+        $objects = $elements->map(function (Element $element) {
+            /** @var \rias\scout\behaviors\SearchableBehavior $element */
+            if (empty($searchableData = $element->toSearchableArray($this->scoutIndex))) {
+                return;
+            }
+
+            return array_merge(
+                ['objectID' => $element->id],
+                $searchableData,
+                ['id' => strval($element->id)]
+            );
+        })->filter()->values()->all();
+
+        return $objects;
+
+        // if (empty($this->scoutIndex->splitElementsOn)) {
+        //     return $objects;
+        // }
+
+        // $result = $this->splitObjects($objects);
+
+        // $this->delete($result['delete']);
+
+        // $objects = $result['save'];
+
+        // return $objects;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -7,6 +7,7 @@ use craft\base\Model;
 use Exception;
 use Illuminate\Support\Collection;
 use rias\scout\engines\AlgoliaEngine;
+use rias\scout\engines\TypesenseEngine;
 use rias\scout\engines\Engine;
 use rias\scout\ScoutIndex;
 
@@ -35,7 +36,7 @@ class Settings extends Model
     public $priority = 1024;
 
     /** @var string */
-    public $engine = AlgoliaEngine::class;
+    public $engine = TypesenseEngine::class;
 
     /** @var ScoutIndex[] */
     public $indices = [];

--- a/src/serializer/Serializer.php
+++ b/src/serializer/Serializer.php
@@ -2,7 +2,7 @@
 
 namespace rias\scout\serializer;
 
-class AlgoliaSerializer extends \League\Fractal\Serializer\ArraySerializer
+class Serializer extends \League\Fractal\Serializer\ArraySerializer
 {
     /**
      * Serialize a collection.

--- a/tests/unit/FractalArraySerializerTest.php
+++ b/tests/unit/FractalArraySerializerTest.php
@@ -6,7 +6,7 @@ use Codeception\Test\Unit;
 use FractalMockTransformers;
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
-use rias\scout\serializer\AlgoliaSerializer;
+use rias\scout\serializer\Serializer;
 
 class FractalArraySerializerTest extends Unit
 {
@@ -21,7 +21,7 @@ class FractalArraySerializerTest extends Unit
     /** @test **/
     public function collection_should_be_index_array()
     {
-        $dataSet = (new Manager())->setSerializer(new AlgoliaSerializer())
+        $dataSet = (new Manager())->setSerializer(new Serializer())
             ->createData(new Collection($this->entries, new FractalMockTransformers()))
             ->toArray();
 
@@ -32,7 +32,7 @@ class FractalArraySerializerTest extends Unit
     public function collection_should_be_multidimensional_array()
     {
         $dataSet = (new Manager())
-            ->setSerializer(new AlgoliaSerializer())
+            ->setSerializer(new Serializer())
             ->createData(new Collection($this->entries, new FractalMockTransformers(), 'entries'))
             ->toArray();
 


### PR DESCRIPTION
This is a work in process. Just opening a draft PR so I can document my progress.

TODO:
- [ ] Expose configuration options for Typesense
- [ ] Allow specifying engine in configuration (i.e. Typesense or Algolia)
- [ ] Support for split objects
- [ ] Support for collection settings
- [ ] Figure out how to handle IDs (Typesense uses `id` rather than `objectID`)