### PR TITLE
Fixes #257

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -156,7 +156,7 @@ class Scout extends Plugin
                     /** @var SearchableBehavior $element */
                     $element = $event->element;
 
-                    if (!$element->shouldBeSearchable()) {
+                    if (!$element->hasMethod('searchable') || !$element->shouldBeSearchable()) {
                         return;
                     }
 
@@ -184,7 +184,7 @@ class Scout extends Plugin
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
 
-                if (!$element->shouldBeSearchable()) {
+                if (!$element->hasMethod('searchable') || !$element->shouldBeSearchable()) {
                     return;
                 }
 
@@ -201,18 +201,23 @@ class Scout extends Plugin
             Elements::class,
             Elements::EVENT_AFTER_DELETE_ELEMENT,
             function (ElementEvent $event) {
-                //Skip this step if we already ran the DeIndex function earlier
+                // Skip this step if we already ran the DeIndex function earlier
                 if (Scout::$plugin->getSettings()->queue) {
                     return;
                 }
                 /** @var SearchableBehavior $element */
                 $element = $event->element;
-                $element->unsearchable();
+
+                if ($element->hasMethod('unsearchable')) {
+                    $element->unsearchable();
+                }
 
                 if ($this->beforeDeleteRelated) {
                     $this->beforeDeleteRelated->each(function (Element $relatedElement) {
                         /* @var SearchableBehavior $relatedElement */
-                        $relatedElement->searchable(false);
+                        if ($relatedElement->hasMethod('searchable')) {
+                            $relatedElement->searchable(false);
+                        }
                     });
                 }
             }


### PR DESCRIPTION
Key aim here is to prevent the `Calling unknown method` errors that keep surfacing. It’s assumed that this is a result of other plugins clashing in some manner.

The solution is guarding the behavior method calls with `method_exists`.