### PR TITLE
Feature - Add support for multiple Element Types per Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ This function accepts an `ElementQuery` and should also return an `ElementQuery`
 });
 ```
 
+#### `->getElements(callable $queries)`
+This function can be used to query multiple different Element types. It should return an array of ElementQuery objects.
+
+```php
+->getElements(function () {
+    return [
+        Entry::find()->section('blog'),
+        Category::find()->group('blogCategories'),
+    ];
+});
+```
+
+*Note:* When `->getElements()` is used, `->criteria()` and `->elementType()` are ignored.
+
 #### `->transformer(callable|string|array|TransformerAbstract $transformer)`
 The [transformer](http://fractal.thephpleague.com/transformers/) that should be used to define the data that should be sent to Algolia for each element. If you don’t set this, the default transformer will be used, which includes all of the element’s direct attribute values, but no custom field values.
 

--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -16,11 +16,14 @@ class ScoutIndex
 
     /** @var IndexSettings */
     public $indexSettings;
+	
+		/** @var bool */
+		public $enforceElementType = true;
 
     /** @var string */
     public $elementType = Entry::class;
 
-    /** @var ElementQuery */
+    /** @var ElementQuery|ElementQuery[] */
     public $criteria;
 
     /** @var callable|string|array|\League\Fractal\TransformerAbstract */
@@ -67,6 +70,34 @@ class ScoutIndex
 
         return $this;
     }
+	
+	/**
+	 * @throws Exception
+	 */
+	public function getElements(callable $getElements): self
+		{
+			$elementQueries = $getElements();
+			
+			if ($elementQueries instanceof ElementQuery) {
+				$elementQueries = [$elementQueries];
+			}
+			
+			// loop through $elementQueries and check that they are all ElementQuery objects
+			foreach ($elementQueries as $elementQuery) {
+				if (!$elementQuery instanceof ElementQuery) {
+					throw new Exception('You must return a valid ElementQuery or array of ElementQuery objects from the getElements function.');
+				}
+
+				if (is_null($elementQuery->siteId)) {
+					$elementQuery->siteId = Craft::$app->getSites()->getPrimarySite()->id;
+				}
+			}
+			
+			$this->enforceElementType = false;
+			$this->criteria = $elementQueries;
+			
+			return $this;
+		}
 
     /*
      * @param $transformer callable|string|array|TransformerAbstract

--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -17,8 +17,8 @@ class ScoutIndex
     /** @var IndexSettings */
     public $indexSettings;
 	
-		/** @var bool */
-		public $enforceElementType = true;
+    /** @var bool */
+    public $enforceElementType = true;
 
     /** @var string */
     public $elementType = Entry::class;
@@ -45,15 +45,17 @@ class ScoutIndex
 
     public function elementType(string $class): self
     {
+			
         if (!is_subclass_of($class, Element::class)) {
-            throw new Exception("Invalid Element Type {$class}");
+            throw new Exception("Invalid Element Type {$class}.");
         }
 
         $this->elementType = $class;
 
         return $this;
     }
-
+		
+		
     public function criteria(callable $criteria): self
     {
         $elementQuery = $criteria($this->elementType::find());
@@ -75,29 +77,29 @@ class ScoutIndex
 	 * @throws Exception
 	 */
 	public function getElements(callable $getElements): self
-		{
-			$elementQueries = $getElements();
-			
-			if ($elementQueries instanceof ElementQuery) {
-				$elementQueries = [$elementQueries];
-			}
-			
-			// loop through $elementQueries and check that they are all ElementQuery objects
-			foreach ($elementQueries as $elementQuery) {
-				if (!$elementQuery instanceof ElementQuery) {
-					throw new Exception('You must return a valid ElementQuery or array of ElementQuery objects from the getElements function.');
-				}
+    {
+        $elementQueries = $getElements();
+        
+        if ($elementQueries instanceof ElementQuery) {
+            $elementQueries = [$elementQueries];
+        }
+        
+        // loop through $elementQueries and check that they are all ElementQuery objects
+        foreach ($elementQueries as $elementQuery) {
+            if (!$elementQuery instanceof ElementQuery) {
+                throw new Exception('You must return a valid ElementQuery or array of ElementQuery objects from the getElements function.');
+            }
 
-				if (is_null($elementQuery->siteId)) {
-					$elementQuery->siteId = Craft::$app->getSites()->getPrimarySite()->id;
-				}
-			}
-			
-			$this->enforceElementType = false;
-			$this->criteria = $elementQueries;
-			
-			return $this;
-		}
+            if (is_null($elementQuery->siteId)) {
+                $elementQuery->siteId = Craft::$app->getSites()->getPrimarySite()->id;
+            }
+        }
+        
+        $this->enforceElementType = false;
+        $this->criteria = $elementQueries;
+        
+        return $this;
+    }
 
     /*
      * @param $transformer callable|string|array|TransformerAbstract

--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -45,17 +45,15 @@ class ScoutIndex
 
     public function elementType(string $class): self
     {
-			
         if (!is_subclass_of($class, Element::class)) {
-            throw new Exception("Invalid Element Type {$class}.");
+            throw new Exception("Invalid Element Type {$class}");
         }
 
         $this->elementType = $class;
 
         return $this;
     }
-		
-		
+
     public function criteria(callable $criteria): self
     {
         $elementQuery = $criteria($this->elementType::find());

--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -39,7 +39,7 @@ class SearchableBehavior extends Behavior
 
     public function validatesCriteria(ScoutIndex $scoutIndex): bool
     {
-        if (is_iterable($scoutIndex->criteria)) {
+        if (is_array($scoutIndex->criteria)) {
             foreach($scoutIndex->criteria as $query) {
                 $criteria = clone $query;
         
@@ -48,7 +48,7 @@ class SearchableBehavior extends Behavior
                 }
             }
         return true;
-                
+        
         } else {
             $criteria = clone $scoutIndex->criteria;
     
@@ -64,7 +64,7 @@ class SearchableBehavior extends Behavior
             ->getSettings()
             ->getIndices()
             ->filter(function (ScoutIndex $scoutIndex) {
-                if(is_iterable($scoutIndex->criteria)){
+                if(is_array($scoutIndex->criteria)){
                     $criteriaSiteIds = collect($scoutIndex->criteria)->map(function($criteria){
                         return Arr::wrap($criteria->siteId);
                     })->flatten()->unique()->values()->toArray();

--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -39,23 +39,23 @@ class SearchableBehavior extends Behavior
 
     public function validatesCriteria(ScoutIndex $scoutIndex): bool
     {
-	      if (is_iterable($scoutIndex->criteria)) {
-		      foreach($scoutIndex->criteria as $query) {
-			      $criteria = clone $query;
-			
-			      if (!$criteria->id($this->owner->id)->exists()) {
-				      return false;
-			      }
-		      }
-	        return true;
-					
-		    } else {
-		      $criteria = clone $scoutIndex->criteria;
-		
-		      return $criteria
-			      ->id($this->owner->id)
-			      ->exists();
-	      }
+        if (is_iterable($scoutIndex->criteria)) {
+            foreach($scoutIndex->criteria as $query) {
+                $criteria = clone $query;
+        
+                if (!$criteria->id($this->owner->id)->exists()) {
+                    return false;
+                }
+            }
+        return true;
+                
+        } else {
+            $criteria = clone $scoutIndex->criteria;
+    
+            return $criteria
+                ->id($this->owner->id)
+                ->exists();
+        }
     }
 
     public function getIndices(): Collection
@@ -64,13 +64,13 @@ class SearchableBehavior extends Behavior
             ->getSettings()
             ->getIndices()
             ->filter(function (ScoutIndex $scoutIndex) {
-								if(is_iterable($scoutIndex->criteria)){
-									$criteriaSiteIds = collect($scoutIndex->criteria)->map(function($criteria){
-										return Arr::wrap($criteria->siteId);
-									})->flatten()->unique()->values()->toArray();
-								} else {
-									$criteriaSiteIds = Arr::wrap($scoutIndex->criteria->siteId);
-								}
+                if(is_iterable($scoutIndex->criteria)){
+                    $criteriaSiteIds = collect($scoutIndex->criteria)->map(function($criteria){
+                        return Arr::wrap($criteria->siteId);
+                    })->flatten()->unique()->values()->toArray();
+                } else {
+                    $criteriaSiteIds = Arr::wrap($scoutIndex->criteria->siteId);
+                }
                 $siteIds = array_map(function ($siteId) {
                     return (int) $siteId;
                 }, $criteriaSiteIds);

--- a/src/console/controllers/scout/IndexController.php
+++ b/src/console/controllers/scout/IndexController.php
@@ -67,9 +67,7 @@ class IndexController extends BaseController
 		            $totalElements = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
 			            return $carry + $query->count();
 		            }, 0);
-		
-		            
-		
+                    
 		            foreach($engine->scoutIndex->criteria as $query) {
 			            $elementsUpdated = 0;
 			            $batch = $query->batch(
@@ -98,8 +96,6 @@ class IndexController extends BaseController
 		            }
 	            }
             }
-	
-	        
         });
 
         return ExitCode::OK;

--- a/src/console/controllers/scout/IndexController.php
+++ b/src/console/controllers/scout/IndexController.php
@@ -62,12 +62,12 @@ class IndexController extends BaseController
                 $this->stdout("Added ImportIndex job for '{$engine->scoutIndex->indexName}' to the queue".PHP_EOL, Console::FG_GREEN);
             } else {
 	            // check if $engine->scoutIndex->criteria is iterable
-	            if (is_iterable($engine->scoutIndex->criteria)) {
+	            if (is_array($engine->scoutIndex->criteria)) {
 		            // use array_reduce to get the count of elements
 		            $totalElements = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
 			            return $carry + $query->count();
 		            }, 0);
-                    
+              
 		            foreach($engine->scoutIndex->criteria as $query) {
 			            $elementsUpdated = 0;
 			            $batch = $query->batch(

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -44,37 +44,37 @@ class IndexController extends Controller
             return $this->redirect(UrlHelper::url('utilities/'.ScoutUtility::id()));
         }
 	
-		    // check if $engine->scoutIndex->criteria is iterable
-		    if (is_iterable($engine->scoutIndex->criteria)) {
-			    // use array_reduce to get the count of elements
-			    $elementsCount = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
-				    return $carry + $query->count();
-			    }, 0);
-			
-			    $elementsUpdated = 0;
-			
-			    foreach($engine->scoutIndex->criteria as $query) {
-				    $batch = $query->batch(
-					    Scout::$plugin->getSettings()->batch_size
-				    );
-				
-				    foreach ($batch as $elements) {
-					    $engine->update($elements);
-				    }
-			    }
-			
-		    } else {
-			    $elementsCount = $engine->scoutIndex->criteria->count();
-			
-			    $elementsUpdated = 0;
-			    $batch = $engine->scoutIndex->criteria->batch(
-				    Scout::$plugin->getSettings()->batch_size
-			    );
-			
-			    foreach ($batch as $elements) {
-				    $engine->update($elements);
-			    }
-		    }
+        // check if $engine->scoutIndex->criteria is iterable
+        if (is_iterable($engine->scoutIndex->criteria)) {
+            // use array_reduce to get the count of elements
+            $elementsCount = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
+                return $carry + $query->count();
+            }, 0);
+        
+            $elementsUpdated = 0;
+        
+            foreach($engine->scoutIndex->criteria as $query) {
+                $batch = $query->batch(
+                    Scout::$plugin->getSettings()->batch_size
+                );
+            
+                foreach ($batch as $elements) {
+                    $engine->update($elements);
+                }
+            }
+        
+        } else {
+            $elementsCount = $engine->scoutIndex->criteria->count();
+        
+            $elementsUpdated = 0;
+            $batch = $engine->scoutIndex->criteria->batch(
+                Scout::$plugin->getSettings()->batch_size
+            );
+        
+            foreach ($batch as $elements) {
+                $engine->update($elements);
+            }
+        }
 
         Craft::$app->getSession()->setNotice("Updated {$elementsCount} element(s) in {$engine->scoutIndex->indexName}");
 

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -45,7 +45,7 @@ class IndexController extends Controller
         }
 	
         // check if $engine->scoutIndex->criteria is iterable
-        if (is_iterable($engine->scoutIndex->criteria)) {
+        if (is_array($engine->scoutIndex->criteria)) {
             // use array_reduce to get the count of elements
             $elementsCount = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
                 return $carry + $query->count();

--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -33,10 +33,12 @@ class AlgoliaEngine extends Engine
     public function update($elements)
     {
         $elements = new Collection(Arr::wrap($elements));
-
-        $elements = $elements->filter(function (Element $element) {
-            return get_class($element) === $this->scoutIndex->elementType;
-        });
+				
+				if($this->scoutIndex->enforceElementType) {
+					$elements = $elements->filter(function (Element $element) {
+						return get_class($element) === $this->scoutIndex->elementType;
+					});
+				}
 
         if ($elements->isEmpty()) {
             return;

--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -34,11 +34,11 @@ class AlgoliaEngine extends Engine
     {
         $elements = new Collection(Arr::wrap($elements));
 				
-				if($this->scoutIndex->enforceElementType) {
-					$elements = $elements->filter(function (Element $element) {
-						return get_class($element) === $this->scoutIndex->elementType;
-					});
-				}
+        if($this->scoutIndex->enforceElementType) {
+            $elements = $elements->filter(function (Element $element) {
+                return get_class($element) === $this->scoutIndex->elementType;
+            });
+        }
 
         if ($elements->isEmpty()) {
             return;

--- a/src/jobs/ImportIndex.php
+++ b/src/jobs/ImportIndex.php
@@ -23,7 +23,7 @@ class ImportIndex extends BaseJob
         }
 				
 				// check if $engine->scoutIndex->criteria is iterable
-        if (is_iterable($engine->scoutIndex->criteria)) {
+        if (is_array($engine->scoutIndex->criteria)) {
 					// use array_reduce to get the count of elements
           $elementsCount = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
             return $carry + $query->count();

--- a/src/jobs/ImportIndex.php
+++ b/src/jobs/ImportIndex.php
@@ -21,17 +21,41 @@ class ImportIndex extends BaseJob
         if (!$engine) {
             return;
         }
-
-        $elementsCount = $engine->scoutIndex->criteria->count();
-        $elementsUpdated = 0;
-        $batch = $engine->scoutIndex->criteria->batch(
-            Scout::$plugin->getSettings()->batch_size
-        );
-
-        foreach ($batch as $elements) {
-            $engine->update($elements);
-            $elementsUpdated += count($elements);
-            $this->setProgress($queue, $elementsUpdated / $elementsCount);
+				
+				// check if $engine->scoutIndex->criteria is iterable
+        if (is_iterable($engine->scoutIndex->criteria)) {
+					// use array_reduce to get the count of elements
+          $elementsCount = array_reduce($engine->scoutIndex->criteria, function ($carry, $query) {
+            return $carry + $query->count();
+          }, 0);
+	
+	        $elementsUpdated = 0;
+					
+					foreach($engine->scoutIndex->criteria as $query) {
+						$batch = $query->batch(
+							Scout::$plugin->getSettings()->batch_size
+						);
+						
+						foreach ($batch as $elements) {
+							$engine->update($elements);
+							$elementsUpdated += count($elements);
+							$this->setProgress($queue, $elementsUpdated / $elementsCount);
+						}
+					}
+					
+        } else {
+					$elementsCount = $engine->scoutIndex->criteria->count();
+	
+	        $elementsUpdated = 0;
+	        $batch = $engine->scoutIndex->criteria->batch(
+		        Scout::$plugin->getSettings()->batch_size
+	        );
+	
+	        foreach ($batch as $elements) {
+		        $engine->update($elements);
+		        $elementsUpdated += count($elements);
+		        $this->setProgress($queue, $elementsUpdated / $elementsCount);
+	        }
         }
     }
 

--- a/src/templates/utility.twig
+++ b/src/templates/utility.twig
@@ -2,10 +2,12 @@
     {% for index in stats %}
         <h2 style="width: 100%;">
             {{ index.name }}
-            {% if index.site == "all" %}
+            {% if index.sites == "all" %}
                 <span class="light">&ndash; {{ "All sites"|t('scout') }}</span>&nbsp;
             {% else %}
-                <span class="light">&ndash; {{ index.site.name }}</span>&nbsp;
+              {% for site in index.sites %}
+                <span class="light">&ndash; {{ site.name }}</span>&nbsp;
+              {% endfor %}
             {% endif %}
             <span class="light">&ndash; </span><small class="light">{{ index.elementType }}</small>
         </h2>

--- a/src/utilities/ScoutUtility.php
+++ b/src/utilities/ScoutUtility.php
@@ -32,26 +32,26 @@ class ScoutUtility extends Utility
         $engines = Scout::$plugin->getSettings()->getEngines();
 
         $stats = $engines->map(function (Engine $engine) {
-						// loop through criteria to get siteId from each criteria
-	          $engineCriteria = collect(Arr::wrap($engine->scoutIndex->criteria));
+            // loop through criteria to get siteId from each criteria
+            $engineCriteria = collect(Arr::wrap($engine->scoutIndex->criteria));
 						
-						$criteriaSites = $engineCriteria->map(function($criteria){
-							return $criteria->siteId;
-						})->flatten()->unique()->values()->toArray();
-						
-						if (count($criteriaSites) === 1 && $criteriaSites[0] === '*') {
-							$sites = 'all';
-						} else {
-							$sites = collect($criteriaSites)->map(function($siteId){
-								return Craft::$app->getSites()->getSiteById($siteId);
-							})->implode('name', ', ');
-						}
-						
-						$totalElements = $engineCriteria->reduce(function($carry, $criteria){
-							return $carry + $criteria->count();
-						}, 0);
-						
-						$elementType = $engine->scoutIndex->enforceElementType ? $engine->scoutIndex->elementType : 'Mixed Element Types';
+            $criteriaSites = $engineCriteria->map(function($criteria){
+                return $criteria->siteId;
+            })->flatten()->unique()->values()->toArray();
+            
+            if (count($criteriaSites) === 1 && $criteriaSites[0] === '*') {
+                $sites = 'all';
+            } else {
+                $sites = collect($criteriaSites)->map(function($siteId){
+                    return Craft::$app->getSites()->getSiteById($siteId);
+                })->implode('name', ', ');
+            }
+            
+            $totalElements = $engineCriteria->reduce(function($carry, $criteria){
+                return $carry + $criteria->count();
+            }, 0);
+            
+            $elementType = $engine->scoutIndex->enforceElementType ? $engine->scoutIndex->elementType : 'Mixed Element Types';
 				
             return [
                 'name'        => $engine->scoutIndex->indexName,


### PR DESCRIPTION
I came across https://github.com/studioespresso/craft-scout/issues/69#issuecomment-548764036 as I had a similar need and thought I would submit a PR for it. It closely resembles the suggested syntax [here](https://github.com/studioespresso/craft-scout/issues/69#issuecomment-616563983) but differs in that my implementation returns an array of query objects rather than merging the two. Open to any edits or feedback!