### PR TITLE
Make `SearchableBehavior::getRelatedElements()` configurable

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -83,4 +83,13 @@ return [
      * Make this false to use the single item itself.
      */
     'useOriginalRecordIfSplitValueIsArrayOfOne' => true,
+
+    /**
+     * The element types to look for when indexRelations is enabled.
+     * By default, all Craft elements are checked for relations.
+     * Use this to avoid unnecissary queries to Elements that aren't
+     * used by your indices or to check custom Elements that may be
+     * related to your indices
+     */
+    'relatedElementTypes' => [],
 ];

--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -131,8 +131,17 @@ class SearchableBehavior extends Behavior
 
     public function getRelatedElements(): Collection
     {
-        if (!Scout::$plugin->getSettings()->sync) {
+        $settings = Scout::$plugin->getSettings();
+
+        if (!$settings->sync) {
             return new Collection();
+        }
+
+        if (!empty($settings->relatedElementTypes)) {
+            return Collection::make($settings->relatedElementTypes)
+                ->flatMap(function($className) {
+                    return $className::find()->relatedTo($this->owner)->site('*')->all();
+                });
         }
 
         $assets = Asset::find()->relatedTo($this->owner)->site('*')->all();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -58,6 +58,9 @@ class Settings extends Model
     /** @var bool */
     public $useOriginalRecordIfSplitValueIsArrayOfOne = true;
 
+    /** @var string[] An array of ::class strings */
+    public $relatedElementTypes = [];
+
     public function fields(): array
     {
         $fields = parent::fields();


### PR DESCRIPTION
### Overview

Bringing ticket https://github.com/studioespresso/craft-scout/issues/242 is back from the dead.

--- 

I'm working on a Craft Commerce site with about ~250,000~ 650,000 SKUs.

At that scale, we hit memory limit exceeded errors for some of our Entries that have lots of relationships to Products.

Commenting out [these lines](https://github.com/studioespresso/craft-scout/blob/master/src/behaviors/SearchableBehavior.php#L150-L151) in SearchableBehavior::getRelatedElements resolved our issue.

This got me thinking... for many use cases, checking all of these Element Types is overkill. Most of our indexes only have relations between Entry and Asset elements. 

Our project still need to index relations, but by removing most Element types from that check, we improve our performance by quite a bit.



