### PR TITLE
Support replica index configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,33 @@ The IndexSettings object provides autocompletion for all Algolia's settings
 )
 ```
 
+### Replicas
+
+Replicas can be created with the `replicas` function on `IndexSettings`. To configure replicas, include them in the `indices` array and set their `replicaIndex` to `true` so that they are not included in any syncing operations.
+
+Replica indices can have their configuration updated using the `./craft scout/settings/update` console command.
+
+```php
+<?php
+
+return [
+    'indices' => [
+        \rias\scout\ScoutIndex::create('Products')
+            // ...
+            ->indexSettings(
+                \rias\scout\IndexSettings::create()
+                    ->minWordSizefor1Typo(4)
+                    ->replicas(['virtual(Products_desc)'])
+            )
+    ],
+    [
+        \rias\scout\ScoutIndex::create('Products_desc')
+            ->replicaIndex(true)
+            ->indexSettings(IndexSettings::create()->customRanking(['desc(price)'])),
+    ],
+];
+```
+
 ## Twig variables
 You can access the Algolia settings set in your config file through the following Twig variables.
 

--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -30,6 +30,9 @@ class ScoutIndex extends BaseObject
     /** @var array */
     public $splitElementsOn = [];
 
+    /** @var bool */
+    public $replicaIndex = false;
+
     /** @var callable|ElementQuery */
     private $_criteria;
 
@@ -131,6 +134,17 @@ class ScoutIndex extends BaseObject
     public function indexSettings(IndexSettings $indexSettings): self
     {
         $this->indexSettings = $indexSettings;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $replicaIndex Whether to mark this index as a replica index and skip syncing.
+     * @return $this
+     */
+    public function replicaIndex(bool $replicaIndex): self
+    {
+        $this->replicaIndex = $replicaIndex;
 
         return $this;
     }

--- a/src/console/controllers/scout/IndexController.php
+++ b/src/console/controllers/scout/IndexController.php
@@ -36,7 +36,7 @@ class IndexController extends BaseController
 
         $engines = Scout::$plugin->getSettings()->getEngines();
         $engines->filter(function (Engine $engine) use ($index) {
-            return $index === '' || $engine->scoutIndex->indexName === $index;
+            return !$engine->scoutIndex->replicaIndex && ($index === '' || $engine->scoutIndex->indexName === $index);
         })->each(function (Engine $engine) {
             $engine->flush();
             $this->stdout("Flushed index {$engine->scoutIndex->indexName}\n", Console::FG_GREEN);
@@ -50,7 +50,7 @@ class IndexController extends BaseController
         $engines = Scout::$plugin->getSettings()->getEngines();
 
         $engines->filter(function (Engine $engine) use ($index) {
-            return $index === '' || $engine->scoutIndex->indexName === $index;
+            return !$engine->scoutIndex->replicaIndex && ($index === '' || $engine->scoutIndex->indexName === $index);
         })->each(function (Engine $engine) {
             if ($this->queue) {
                 Craft::$app->getQueue()

--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -32,6 +32,10 @@ class AlgoliaEngine extends Engine
      */
     public function update($elements)
     {
+        if ($this->scoutIndex->replicaIndex) {
+            return;
+        }
+
         $elements = new Collection(Arr::wrap($elements));
 
         $elements = $elements->filter(function (Element $element) {
@@ -51,6 +55,10 @@ class AlgoliaEngine extends Engine
 
     public function delete($elements)
     {
+        if ($this->scoutIndex->replicaIndex) {
+            return;
+        }
+
         $elements = new Collection(Arr::wrap($elements));
 
         $index = $this->algolia->initIndex($this->scoutIndex->indexName);
@@ -78,6 +86,10 @@ class AlgoliaEngine extends Engine
 
     public function flush()
     {
+        if ($this->scoutIndex->replicaIndex) {
+            return;
+        }
+
         $index = $this->algolia->initIndex($this->scoutIndex->indexName);
         $index->clearObjects();
     }

--- a/src/templates/utility.twig
+++ b/src/templates/utility.twig
@@ -2,54 +2,62 @@
     {% for index in stats %}
         <h2 style="width: 100%;">
             {{ index.name }}
-            {% if index.site == "all" %}
-                <span class="light">&ndash; {{ "All sites"|t('scout') }}</span>&nbsp;
+            {% if index.replicaIndex == false %}
+                {% if index.site == "all" %}
+                    <span class="light">&ndash; {{ "All sites"|t('scout') }}</span>&nbsp;
+                {% else %}
+                    <span class="light">&ndash; {{ index.site.name }}</span>&nbsp;
+                {% endif %}
+                <span class="light">&ndash; </span><small class="light">{{ index.elementType }}</small>
             {% else %}
-                <span class="light">&ndash; {{ index.site.name }}</span>&nbsp;
+                <span class="light">&ndash; {{ "Replica index"|t('scout') }}</span>&nbsp;
             {% endif %}
-            <span class="light">&ndash; </span><small class="light">{{ index.elementType }}</small>
         </h2>
         <table class="data fullwidth fixed-layout">
             <tbody>
-            <tr>
-                <th class="light">{{ "Elements in Craft"|t("scout") }}</th>
-                <td>{{ index.elements }}</td>
-            </tr>
-            <tr>
-                <th class="light">{{ "Records in Index"|t("scout") }}</th>
-                <td>{{ index.indexed }}</td>
-            </tr>
+            {% if index.replicaIndex == false %}
+                <tr>
+                    <th class="light">{{ "Elements in Craft"|t("scout") }}</th>
+                    <td>{{ index.elements }}</td>
+                </tr>
+                <tr>
+                    <th class="light">{{ "Records in Index"|t("scout") }}</th>
+                    <td>{{ index.indexed }}</td>
+                </tr>
+            {% endif %}
             <tr>
                 <th class="light">
                     {{ "Actions"|t("scout") }}<br>
                     <small style="font-weight: normal;">{{ "These can take a while to process."|t("scout") }}</small>
                 </th>
                 <td>
-                    <div style="display: flex; justify-content: left; flex-wrap: wrap;">
-                        {% include 'scout/_partials/action' with {
-                            action: {
-                                name: 'Refresh' | t('scout'),
-                                slug: 'refresh',
-                                index: index.name
-                            }
-                        } %}
-                        &nbsp;
-                        {% include 'scout/_partials/action' with {
-                            action: {
-                                name: 'Import' | t('scout'),
-                                slug: 'import',
-                                index: index.name
-                            }
-                        } %}
-                        &nbsp;
-                        {% include 'scout/_partials/action' with {
-                            action: {
-                                name: 'Flush' | t('scout'),
-                                slug: 'flush',
-                                index: index.name
-                            }
-                        } %}
-                    </div>
+                    {% if index.replicaIndex == false %}
+                        <div style="display: flex; justify-content: left; flex-wrap: wrap;">
+                            {% include 'scout/_partials/action' with {
+                                action: {
+                                    name: 'Refresh' | t('scout'),
+                                    slug: 'refresh',
+                                    index: index.name
+                                }
+                            } %}
+                            &nbsp;
+                            {% include 'scout/_partials/action' with {
+                                action: {
+                                    name: 'Import' | t('scout'),
+                                    slug: 'import',
+                                    index: index.name
+                                }
+                            } %}
+                            &nbsp;
+                            {% include 'scout/_partials/action' with {
+                                action: {
+                                    name: 'Flush' | t('scout'),
+                                    slug: 'flush',
+                                    index: index.name
+                                }
+                            } %}
+                        </div>
+                    {% endif %}
                     <div style="display: flex; justify-content: left; flex-wrap: wrap;">
                         {% if index.hasSettings %}
                             {% include 'scout/_partials/action' with {

--- a/src/utilities/ScoutUtility.php
+++ b/src/utilities/ScoutUtility.php
@@ -31,14 +31,20 @@ class ScoutUtility extends Utility
         $engines = Scout::$plugin->getSettings()->getEngines();
 
         $stats = $engines->map(function (Engine $engine) {
-            return [
-                'name'        => $engine->scoutIndex->indexName,
-                'elementType' => $engine->scoutIndex->elementType,
-                'site'        => $engine->scoutIndex->criteria->siteId === '*' ? 'all' : Craft::$app->getSites()->getSiteById($engine->scoutIndex->criteria->siteId),
-                'indexed'     => $engine->getTotalRecords(),
-                'elements'    => $engine->scoutIndex->criteria->count(),
-                'hasSettings' => $engine->scoutIndex->indexSettings ?? null,
+            $stats = [
+                'name'         => $engine->scoutIndex->indexName,
+                'replicaIndex' => $engine->scoutIndex->replicaIndex,
+                'hasSettings'  => $engine->scoutIndex->indexSettings ?? null,
             ];
+            if (!$engine->scoutIndex->replicaIndex) {
+                $stats = array_merge($stats, [
+                    'elementType'  => $engine->scoutIndex->elementType,
+                    'site'         => $engine->scoutIndex->criteria->siteId === '*' ? 'all' : Craft::$app->getSites()->getSiteById($engine->scoutIndex->criteria->siteId),
+                    'indexed'      => $engine->getTotalRecords(),
+                    'elements'     => $engine->scoutIndex->criteria->count(),
+                ]);
+            }
+            return $stats;
         });
 
         return $view->renderTemplate('scout/utility', [


### PR DESCRIPTION
Resolves #114 

This PR adds a flag on `ScoutIndex` to flag an index as a replica which prevents it from being sync'd by the plugin.

Replica indices can be configured by adding them to the `indices` property in config like you would a regular index with the exception of setting the flag using `->replicaIndex(true)`.

```php
[
    'indices' => [
        ScoutIndex::create('Products')
            // ...
            ->indexSettings(
                IndexSettings::create()->replicas(['virtual(Products_desc)'])
            )
    ],
    [
        ScoutIndex::create('Products_desc')
            ->replicaIndex(true)
            ->indexSettings(IndexSettings::create()->customRanking(['desc(price)'])),
    ],
]
```

This roughly follows how Algolia recommends configuring replicas in code: https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/how-to/sort-by-attribute/#example-relevant-sort-with-a-virtual-replica

Updated utilities view:

![image](https://github.com/studioespresso/craft-scout/assets/4161106/3293d508-dc2b-446f-958e-ae8d1631d318)
