### PR TITLE
feat: backport fix for #266 to Craft 3

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -162,7 +162,10 @@ class Scout extends Plugin
 
                     if (Scout::$plugin->getSettings()->queue) {
                         Craft::$app->getQueue()->push(
-                            new IndexElement(['id' => $element->id])
+                            new IndexElement([
+                                'id' => $element->id,
+                                'siteId' => $element->site->id,
+                            ])
                         );
                     } else {
                         $element->searchable();

--- a/src/jobs/IndexElement.php
+++ b/src/jobs/IndexElement.php
@@ -13,9 +13,12 @@ class IndexElement extends BaseJob
     /** @var int */
     public $id;
 
+    /** @var int */
+    public $siteId;
+
     public function execute($queue)
     {
-        $element = Craft::$app->getElements()->getElementById($this->id);
+        $element = Craft::$app->getElements()->getElementById($this->id, null, $this->siteId);
 
         if (!$element) {
             return;


### PR DESCRIPTION
The issue described in #266 also affects Craft 3 version of this plugin. So this PR back-ports the fix as is.

What we usually do in our own custom modules when it comes to potentially off-loading to the queue, is to always run the job. But conditionally on the queue.

So, in this case we would have done:

```
$job = new IndexElement([
    'id' => $element->id,
    'siteId' => $element->site->id,
]);
$queue = Craft::$app->getQueue();
if (Scout::$plugin->getSettings()->queue) {
    $queue->push($job);
} else {
    $job->execute($queue);
}
```

This way both paths end up doing the same work. Now if `Scout::$plugin->getSettings()->queue === false`, the extra work that the Job does does not get executed. 

I didn't think I should "pollute" this PR with that, but I could put this in a new PR if interested?