### PR TITLE
Fixed missing deletion of orphans of split elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Fixed
+- Fixed missing deletion of orphans of split elements ([#259](https://github.com/studioespresso/craft-scout/issues/259))
+
 ## 3.3.3-beta.1 - 2023-12-06
 ### Fixed
 - This beta release is a first try at resolving an issue with deindexing of element not working properly. ([#281](https://github.com/studioespresso/craft-scout/issues/281))

--- a/src/engines/Engine.php
+++ b/src/engines/Engine.php
@@ -43,16 +43,13 @@ abstract class Engine
                     $objectToSave['distinctID'] = $objectToSave['objectID'];
                     $objectsToSave[] = $objectToSave;
                 }
-
-                continue;
+            } else {
+                foreach ($splittedObjects as $part => $splittedObject) {
+                    $splittedObject['distinctID'] = $splittedObject['objectID'];
+                    $splittedObject['objectID'] = "{$splittedObject['objectID']}_{$part}";
+                    $objectsToSave[] = $splittedObject;
+                }
             }
-
-            foreach ($splittedObjects as $part => $splittedObject) {
-                $splittedObject['distinctID'] = $splittedObject['objectID'];
-                $splittedObject['objectID'] = "{$splittedObject['objectID']}_{$part}";
-                $objectsToSave[] = $splittedObject;
-            }
-
             $objectsToDelete[] = $object;
         }
 


### PR DESCRIPTION
This fixes #259

I have not seen anything break, and orphans are now deleted as expected in the indexes I have tested manually, but I have not run any unit tests (or added any new ones), as there are no instructions on what is needed to set that up.

I can try to add unit tests if some instructions are given.