### PR TITLE
feat!: upgrade `league/fractal` to 0.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^8.0.2",
         "craftcms/cms": "^4.3.5",
         "algolia/algoliasearch-client-php": "^2.3|^3.0",
-        "league/fractal": "^0.18|^0.19"
+        "league/fractal": "^0.20"
     },
     "repositories": [
         {

--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -21,7 +21,7 @@ class ScoutIndex extends BaseObject
     /** @var IndexSettings */
     public $indexSettings;
 
-    /** @var string */
+    /** @var <class-string> */
     public $elementType = Entry::class;
 
     /** @var callable|string|array|\League\Fractal\TransformerAbstract */

--- a/src/serializer/AlgoliaSerializer.php
+++ b/src/serializer/AlgoliaSerializer.php
@@ -7,12 +7,12 @@ class AlgoliaSerializer extends \League\Fractal\Serializer\ArraySerializer
     /**
      * Serialize a collection.
      *
-     * @param string $resourceKey
+     * @param ?string $resourceKey
      * @param array  $data
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection(?string $resourceKey, array $data): array
     {
         if ($resourceKey) {
             return [$resourceKey => $data];


### PR DESCRIPTION
Upgrade to most recent branch of `league/fractal`. This makes sense to do now since `craftcms/element-api` has also done this upgrade in its recent 4.x line. This should probably also be ported to the v5-develop branch, or maybe only introduce with that branche?

BREAKING CHANGE: Fractal's public API has changed in classes such as `\League\Fractal\Serializer\ArraySerializer`