### PR TITLE
Don't create an element query right away from ScoutIndex

### DIFF
--- a/src/ScoutIndex.php
+++ b/src/ScoutIndex.php
@@ -41,7 +41,6 @@ class ScoutIndex extends BaseObject
         parent::__construct($config);
 
         $this->indexName = $indexName;
-        $this->_criteria = $this->elementType::find();
     }
 
     public static function create(string $indexName): self
@@ -76,6 +75,10 @@ class ScoutIndex extends BaseObject
      */
     public function getCriteria(): ElementQuery
     {
+        if (!isset($this->_criteria)) {
+            return $this->_criteria = $this->elementType::find();
+        }
+
         if (is_callable($this->_criteria)) {
             $elementQuery = call_user_func(
                 $this->_criteria,


### PR DESCRIPTION
`ScoutIndex::__construct()` was creating an element query, which is problematic because `ScoutIndex` objects are [meant to be created](https://github.com/studioespresso/craft-scout/tree/master?tab=readme-ov-file#example-index-configuration) from the plugin’s config file, which will get executed before Craft is fully initialized. (Even the `Scout` class won’t have been loaded yet at that point, let alone other plugins.) If another plugin hasn’t been loaded yet, it won’t have had a chance to register event listeners for the element query yet, etc.

In one case we are seeing this, combined with some other random plugin [also doing too much before the app is fully initialized](https://github.com/craftcms/commerce/pull/3518/files), end up causing a `Class "craft\behaviors\CustomFieldBehavior" does not exist` error whenever the class needs to be recreated.

This fix defers the element query creation until the first time it’s actually needed, which in theory will be a bit further along in the request.

Plus, it avoids needlessly creating an element query if `ScoutIndex::criteria()` ends up getting called, in which case `$this->_criteria` was getting discarded in favor of a new element query instance, anyway.