### PR TITLE
Ignore Replica Indices in SearchableBehavior.php

### DIFF
--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -65,6 +65,10 @@ class SearchableBehavior extends Behavior
             ->getSettings()
             ->getIndices()
             ->filter(function (ScoutIndex $scoutIndex) {
+                if ($scoutIndex->replicaIndex) {
+                    return false;
+                }
+
                 if (is_array($scoutIndex->criteria)) {
                     $criteriaSiteIds = collect($scoutIndex->criteria)->map(function ($criteria) {
                         return Arr::wrap($criteria->siteId);


### PR DESCRIPTION
Replica Indices will have no criteria configured.

This is intended to resolve [Issue 303](https://github.com/studioespresso/craft-scout/issues/303) for the Craft 4 compatible version of Scout.