### PR TITLE
Fix for elements not being deindexed when indexRelations config is false and queue is enabled

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -183,8 +183,6 @@ class Scout extends Plugin
             function (ElementEvent $event) {
                 if (!Scout::$plugin->getSettings()->indexRelations) {
                     $this->beforeDeleteRelated = new Collection();
-
-                    return;
                 }
 
                 /** @var SearchableBehavior $element */


### PR DESCRIPTION
When the `indexRelations` config is set to `false` and the queue is used, the DeindexElement queue job is not reached in the before delete element event.

This results in the element not be deindexed in Algolia.

Removing the return here ensures the queue job gets pushed.