### PR TITLE
Fix regression when indexRelations is false

### DIFF
--- a/src/Scout.php
+++ b/src/Scout.php
@@ -202,8 +202,6 @@ class Scout extends Plugin
             function(ElementEvent $event) {
                 if (!Scout::$plugin->getSettings()->indexRelations) {
                     $this->beforeDeleteRelated = new Collection();
-
-                    return;
                 }
 
                 /** @var SearchableBehavior $element */


### PR DESCRIPTION
This was a fix from an earlier version of Scout that looks like it didn't make it into version 5 https://github.com/mike-moreau/craft-scout/commit/5705d4c9b735e4b76f8b1b10cd10175f32be14b3